### PR TITLE
feat Refreshable Menus

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomenus/menus/EcoMenu.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomenus/menus/EcoMenu.kt
@@ -3,6 +3,7 @@ package com.willfp.ecomenus.menus
 import com.willfp.eco.core.config.interfaces.Config
 import com.willfp.eco.core.gui.menu.Menu
 import com.willfp.eco.core.registry.KRegistrable
+import com.willfp.eco.util.openMenu
 import com.willfp.ecomenus.commands.DynamicMenuCommand
 import com.willfp.ecomenus.plugin
 import com.willfp.libreforge.EmptyProvidedHolder
@@ -11,7 +12,9 @@ import com.willfp.libreforge.conditions.Conditions
 import com.willfp.libreforge.effects.Effects
 import com.willfp.libreforge.effects.executors.impl.NormalExecutorFactory
 import com.willfp.libreforge.toDispatcher
+import org.bukkit.Bukkit
 import org.bukkit.entity.Player
+import org.bukkit.scheduler.BukkitTask
 
 class EcoMenu(
     override val id: String,
@@ -40,10 +43,26 @@ class EcoMenu(
         ViolationContext(plugin, "menu $id close effects")
     )
 
+    private val refreshEnabled = config.getBool("refresh.enabled")
+    private val refreshInterval = config.getInt("refresh.interval").toLong().coerceAtLeast(1)
+
+    private var refreshTask: BukkitTask? = null
+
     init {
         if (commandName != null) {
             DynamicMenuCommand(this, commandName).register()
         }
+        if (refreshEnabled) {
+            refreshTask = plugin.scheduler.runTimer(refreshInterval, refreshInterval) {
+                Bukkit.getOnlinePlayers()
+                    .filter { it.openMenu == menu }
+                    .forEach { menu.refresh(it) }
+            }
+        }
+    }
+
+    fun dispose() {
+        refreshTask?.cancel()
     }
 
     fun open(player: Player, parent: Menu? = null) {
@@ -65,7 +84,7 @@ class EcoMenu(
     fun handleClose(player: Player) {
         closeEffects?.trigger(player.toDispatcher())
         val prev = menu.previousMenus[player].popOrNull()
-        plugin.scheduler.runLater(1)  {
+        plugin.scheduler.runLater(1) {
             if (prev != null && prev != menu) {
                 prev.open(player)
             }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomenus/menus/EcoMenus.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomenus/menus/EcoMenus.kt
@@ -9,6 +9,7 @@ object EcoMenus : ConfigCategory("menu", "menus") {
     private val registry = Registry<EcoMenu>()
 
     override fun clear(plugin: LibreforgePlugin) {
+        registry.values().forEach { it.dispose() }
         registry.clear()
     }
 

--- a/eco-core/core-plugin/src/main/resources/menus/_example.yml
+++ b/eco-core/core-plugin/src/main/resources/menus/_example.yml
@@ -28,6 +28,12 @@ open-effects: [ ]
 # Effects to run when the GUI is closed
 close-effects: [ ]
 
+# Whether to automatically refresh (re-render) this menu for viewers.
+# interval is in ticks (20 ticks = 1 second).
+refresh:
+  enabled: false
+  interval: 20
+
 # Options for the page arrows
 # If on the first page, the backwards arrow will not be shown,
 # and if on the last page, the forwards arrow will not be shown.


### PR DESCRIPTION
Add per-menu auto-refresh config option

Each menu YAML now supports a `refresh` block:
```yaml
refresh:
  enabled: true
  interval: 20  # ticks (20 = 1s)
```

When enabled, the menu re-renders for all current viewers on the configured tick interval. Tasks are cancelled cleanly on reload.
